### PR TITLE
#160818302 Fix heroku PR review apps deployment bug

### DIFF
--- a/authors/settings.py
+++ b/authors/settings.py
@@ -24,13 +24,7 @@ SECRET_KEY = '7pgozr2jn7zs_o%i8id6=rddie!*0f0qy3$oy$(8231i^4*@u3'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = [
-    '127.0.0.1',
-    'localhost',
-    'ah-code-blooded.herokuapp.com',  # the production host
-    'ah-code-blooded-staging.herokuapp.com',  # the staging host
-    'ah-code-blooded-staging-pr-*.herokuapp.com'  # the pr dynamic host
-]
+ALLOWED_HOSTS = ['*']
 
 # Application definition
 


### PR DESCRIPTION
### What does this PR do?
Fix `Heroku Review Apps` deployment failure.

### Description of the task to be completed?
Review apps that are auto-deployed when PRs are raised should not fail. The cause of the failure is whitelisting of allowed hosts.

### How this should be manually tested?
This PR can be manually tested by raising a pull request. This triggers auto-deployment of a review app for the PR. This very PR confirms that the fix is working as can be seen below:

<img width="552" alt="code-blooded-pr-deployed" src="https://user-images.githubusercontent.com/8180548/46152941-c31c2380-c27a-11e8-8558-632178959972.png">

### What are the relevant pivotal tracker stories?
[#160818302](https://www.pivotaltracker.com/story/show/160818302)