### PR TITLE
#161479358 Fix swagger schema generation bug

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -640,6 +640,7 @@ class FavouriteArticleApiView(APIView):
 
 class LikeComments(UpdateAPIView):
     """This class Handles likes of comment"""
+    serializer_class = CommentSerializer
 
     def update(self, request, *args, **kwargs):  # NOQA
         """This method updates liking of comment"""
@@ -682,6 +683,7 @@ class LikeComments(UpdateAPIView):
 
 class DislikeComments(UpdateAPIView):
     """This class Handles dislikes of comment"""
+    serializer_class = CommentSerializer
 
     def update(self, request, *args, **kwargs):  # NOQA
         """This method updates liking of comment"""


### PR DESCRIPTION
### What does this PR do?
Fix `Swagger` schema generation bug.

### Description of the task to be completed?
Swagger documentation should be displayed when the project root endpoint is accessed.

### How this should be manually tested?
This PR can be manually tested by visiting the [Heroku Review App](https://ah-code-blooded-staging-pr-45.herokuapp.com/) for this story. The swagger generated documentation should be displayed.

### The fix for the bug?
Two `article` `view` classes, `LikeComments` and `DislikeComments` don't have the `serializer_class` property specified. Apparently swagger requires view classes to specify the property inorder to generate the documentation schema. Adding the property fixes the bug.

### What are the relevant pivotal tracker stories?
[#161479358](https://www.pivotaltracker.com/story/show/161479358)