### PR TITLE
#161710078 Fix article dislike endpoint

### DIFF
--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
     path('', include(router.urls)),
     path('articles/<slug>/tags/', ArticleTagsAPIView.as_view(), name="article-tags"),
     path('articles/<str:slug>/like/', LikeAPIView.as_view(), name='like'),
-    path('articles/<str:slug>/unlike/', DislikeAPIView.as_view(), name='dislike'),
+    path('articles/<str:slug>/dislike/', DislikeAPIView.as_view(), name='dislike'),
     path('articles/<str:slug>/reactions/', ReactionsAPIView.as_view(), name='reactions'),
     path('articles/search_filter', SearchFilterListAPIView.as_view(), name='search-filter'),
     path('articles/<slug>/rate/', RatingAPIView.as_view(), name='rate-article'),


### PR DESCRIPTION
### What does this PR do?
Fix article dislike endpoint.

### Description of the task to be completed?
The dislike endpoint is:
`articles/<str:slug>/unlike/`

It  should be:
`articles/<str:slug>/dislike/`

### How this should be manually tested?
This PR can be manually tested using Postman via the following endpoints:
1. `POST articles/<str:slug>/dislike/` to dislike an article.
2. `DELETE articles/<str:slug>/dislike/` to un-dislike an article.

### What are the relevant pivotal tracker stories?
[#161710078](https://www.pivotaltracker.com/story/show/161710078)