### PR TITLE
#161810527 Fix CORS origin whitelist

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -26,3 +26,6 @@ export FB_SECRET=
 # client app config - should point to the staging or production app
 export CLIENT_DOMAIN=https://ah-cd-frontend-staging.herokuapp.com
 export CLIENT_RESET_PASSWORD_ROUTE=reset-password
+
+# CORS whitelisted localhost ports
+export LOCALHOST_CORS_WHITELIST=3000,3001,3002,3003,3004

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -215,10 +215,18 @@ STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),
 )
 
-CORS_ORIGIN_WHITELIST = (
-    '0.0.0.0:4000',
-    'localhost:4000',
-)
+# Tell Django the origins from which to allow CORS
+CORS_ORIGIN_WHITELIST = [
+    '0.0.0.0:4000',  # this came with Django
+    'localhost:4000',  # this came with Django
+    os.getenv('CLIENT_DOMAIN'),  # the client app
+]
+
+# Add local ports that may require CORS when working locally
+CORS_ORIGIN_WHITELIST += ['localhost:{}'.format(port) for port in os.getenv('LOCALHOST_CORS_WHITELIST', '').split(',')]
+
+# Convert the CORS whitelist into a tuple so that it is immutable
+CORS_ORIGIN_WHITELIST = tuple(CORS_ORIGIN_WHITELIST)
 
 # Tell Django about the custom `User` model we created. The string
 # `authentication.User` tells Django we are referring to the `User` model in


### PR DESCRIPTION
**What does this PR do?**

Add the client app domain to the CORS whitelist. Additionally provide a way for adding local ports for the sake of local development.

**Description of Task to be completed?**

##### Steps to reproduce
Attempt to make API calls from the client app. For example:
`axios.post('/account/forgot_password/')`

##### Expected
The request should be processed correctly and give the corresponding response.

##### Actual
The request fails with a CORS error. This is because the client application is not on the backend application CORS whitelist.


**How should this be manually tested?**

To test manually:
1. Ensure that the `CLIENT_DOMAIN` env variable is set or atleast one port is provided on the `LOCALHOST_CORS_WHITELIST` env variable.
2. Make an ajax request from either the staging or local client app.

The ajax request should return successfully.

**What are the relevant pivotal tracker stories?**

[161810527](https://www.pivotaltracker.com/story/show/161810527)

**Screenshots**
The client application running locally on port 3000
<img width="586" alt="screen shot 2018-11-08 at 18 06 17" src="https://user-images.githubusercontent.com/8180548/48207154-1a84d780-e381-11e8-9387-ee25b6ff4e7e.png">

Port 3000 is on the `LOCALHOST_CORS_WHITELIST`
<img width="641" alt="screen shot 2018-11-08 at 18 01 31" src="https://user-images.githubusercontent.com/8180548/48207045-da255980-e380-11e8-9ee6-32a770b98624.png">

The client application is able to make ajax requests to the backend
<img width="466" alt="screen shot 2018-11-08 at 18 03 31" src="https://user-images.githubusercontent.com/8180548/48207050-db568680-e380-11e8-89bc-ff688432eb64.png">

