### PR TITLE
#161915297 Fix login return message

### DIFF
--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -28,6 +28,7 @@ from .serializers import (
     LoginSerializer, RegistrationSerializer, UserSerializer, ForgotPasswordSerializer, ResetPasswordSerializers,
     SocialSignUpSerializer, LogoutSerializer
 )
+from authors.apps.profiles.serializers import ProfileSerializer
 from .models import User, BlacklistedToken
 from rest_framework import authentication
 
@@ -111,10 +112,10 @@ class LoginAPIView(CreateAPIView):
         serializer = self.serializer_class(data=user)
         serializer.is_valid(raise_exception=True)
 
+        user = User.objects.get(email=user['email'])
         # return jwt as the response
-        resp = {
-            "token": serializer.data['token']
-        }
+        resp = ProfileSerializer(user.profile).data
+        resp['token'] = serializer.data['token']
 
         return Response(resp, status=status.HTTP_200_OK)
 
@@ -325,8 +326,12 @@ class SocialSignUp(CreateAPIView):
 
             serializer.instance = user
             user.save()
+
+
             return Response(
-                {'token': user.token},
+                {
+                    'token': user.token,
+                },
 
                 status=status.HTTP_201_CREATED
             )


### PR DESCRIPTION
**What does this PR do?**

* adds image, bio and username to the return message

**Any background context you want to provide?**

the front-end fails to integrate properly because to display a users profile, they need to be logged and their profile data stored in the local storage along side the token. 

**What are the relevant pivotal tracker stories?**

[#161915297](https://www.pivotaltracker.com/story/show/161915297)

**Screenshots (if appropriate)**

* previous return
<img width="1134" alt="screenshot 2018-11-13 at 13 09 12" src="https://user-images.githubusercontent.com/38909130/48407317-94351080-e747-11e8-8ad1-63432de619af.png">

* modified return
<img width="1129" alt="screenshot 2018-11-13 at 13 04 50" src="https://user-images.githubusercontent.com/38909130/48407342-a3b45980-e747-11e8-90da-17841a6814d5.png">


**Questions:**

N/A