### PR TITLE
 #161913436 Fix account verification bug

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -26,6 +26,7 @@ export FB_SECRET=
 # client app config - should point to the staging or production app
 export CLIENT_DOMAIN=https://ah-cd-frontend-staging.herokuapp.com
 export CLIENT_RESET_PASSWORD_ROUTE=reset-password
+export CLIENT_ACTIVATE_ACCOUNT_ROUTE=activate-account
 
 # CORS whitelisted localhost ports
 export LOCALHOST_CORS_WHITELIST=3000,3001,3002,3003,3004

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -13,9 +13,7 @@ from requests.exceptions import HTTPError
 from authors.apps.core import client
 from .renderers import UserJSONRenderer
 
-from rest_framework.reverse import reverse
 from django.contrib.auth.tokens import default_token_generator
-from django.contrib.sites.shortcuts import get_current_site
 from django.template.loader import render_to_string
 from django.core.mail import EmailMultiAlternatives
 from django.utils.html import strip_tags
@@ -75,18 +73,14 @@ class RegistrationAPIView(CreateAPIView):
         if send_email:
             email = user.email
             username = user.username
-            domain = get_current_site(request).domain
             from_email = os.getenv("EMAIL_HOST_SENDER")
 
             email_subject = 'Activate your Author\'s Haven account.'
-            activation_link = "http://" + domain + reverse("authentication:activate-account",
-                                                           kwargs={"token": token, "uid": uid})
-            email_message = render_to_string('email_verification.html',
-                                             {
-                                                 'activation_link': activation_link,
-                                                 'title': email_subject,
-                                                 'username': username
-                                             })
+            email_message = render_to_string('email_verification.html', {
+                'activation_link': client.get_activate_account_link(token, uid),
+                'title': email_subject,
+                'username': username
+            })
             text_content = strip_tags(email_message)
             msg = EmailMultiAlternatives(
                 email_subject, text_content, from_email, to=[email])

--- a/authors/apps/core/client.py
+++ b/authors/apps/core/client.py
@@ -7,3 +7,11 @@ def get_domain():
 
 def get_password_reset_link(token):
     return "{}/{}?token={}".format(get_domain(), os.getenv("CLIENT_RESET_PASSWORD_ROUTE"), token)
+
+
+def get_activate_account_link(token, uid):
+    """
+
+    :rtype: object
+    """
+    return "{}/{}?token={}&uid={}".format(get_domain(), os.getenv("CLIENT_ACTIVATE_ACCOUNT_ROUTE"), token, uid)

--- a/authors/apps/core/test_client.py
+++ b/authors/apps/core/test_client.py
@@ -1,0 +1,10 @@
+from django.test import TestCase
+from authors.apps.core.client import get_activate_account_link, get_password_reset_link
+
+
+class TestGenerateLinks(TestCase):
+
+    def test_get_activate_account_link(self):
+        self.assertEqual(get_activate_account_link("token", 'uid'), "http://localhost:3000/activate-account?token=token&uid=uid")
+    def test_get_password_reset_link(self):
+        self.assertEqual(get_password_reset_link('token'), "http://localhost:3000/reset-password?token=token")


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the process behind account verification bug. The account verification link that is sent to the email redirects to the backend via DRF browsable API.

<img width="681" alt="screen shot 2018-11-13 at 15 04 44" src="https://user-images.githubusercontent.com/40663486/48412680-702cfb80-e756-11e8-9992-ed110909fc05.png">


With this behaviour, it is impossible to consume the API from the frontend application. To fix the issue the  verification link should redirects to the frontend application.

**Description of Task to be completed?**

##### Steps to reproduce
1. Create a new account (verification is sent to email")
2. Open verification link on email.

##### Expected
You should be redirected to the frontend application with the verification token and uid as a parameters.

##### Actual
You are redirected to the DRF browsable API.

**How should this be manually tested?**
This can be manually tested by following the following steps using Postman.
1. Register as user.

POST /users
{
	"user": {
		"email": "<your_email>@gmail.com",
		"password": "#haiqPY123",
		"username": "<your_username>"
	}
}

You will receive a verification  link on the email.
3. Follow the link and it will resolve to the frontend application with the verification token  and uid as parameter e.g. http://localhost:3000/activate-account?token=519-6edd3d76e68e6d40879e&uid=Y2hvbWJh
4. Copy the token and uid parameters and use it to verify account.

GET /users/verify-account/519-6edd3d76e68e6d40879/Y2hvbWJh/

You will receive a response indicating that the account has been verified.

**What are the relevant pivotal tracker stories?**

[#161913436](https://www.pivotaltracker.com/story/show/161913436)


**Screenshots**
<img width="902" alt="screen shot 2018-11-13 at 15 32 59" src="https://user-images.githubusercontent.com/40663486/48413658-72dd2000-e759-11e8-8e55-1342089d33da.png">
