### PR TITLE
#161810527 Fix CORS origin for review apps

### DIFF
--- a/authors/settings.py
+++ b/authors/settings.py
@@ -228,6 +228,8 @@ CORS_ORIGIN_WHITELIST += ['localhost:{}'.format(port) for port in os.getenv('LOC
 # Convert the CORS whitelist into a tuple so that it is immutable
 CORS_ORIGIN_WHITELIST = tuple(CORS_ORIGIN_WHITELIST)
 
+CORS_ORIGIN_ALLOW_ALL = True  # allow all origins for the sake of review apps !!! GET PROPER FIX !!!
+
 # Tell Django about the custom `User` model we created. The string
 # `authentication.User` tells Django we are referring to the `User` model in
 # the `authentication` module. This module is registered above in a setting


### PR DESCRIPTION
**What does this PR do?**
Fixes CORS for review apps by allowing all hosts.

**Description of Task to be completed?**
##### Steps to reproduce
Attempt to make API calls from the client review app. For example:
`axios.post('/account/forgot_password/')`

##### Expected
The request should be processed correctly and give the corresponding response.

##### Actual
The request fails with a CORS error. This is because the client review app has a dynamically generated domain which is not on the CORS whitelist.

**How should this be manually tested?**
To test manually:
1. Ensure that the application is running.
    `python manage.py run`
2. Make an `ajax` request from any client app to this app.

NB. You don't have to set any domain to the whitelist via environment variables.

**Any background context you want to provide?**
This fix should be treated as temporary since it allows requests from any origin.

**What are the relevant pivotal tracker stories?**
[#161915991](https://www.pivotaltracker.com/story/show/161915991)

**Screenshots (if appropriate)**
<img width="466" alt="screen shot 2018-11-08 at 18 03 31" src="https://user-images.githubusercontent.com/8180548/48427934-f3604880-e77a-11e8-8476-748c6f0f8b3c.png">
