### PR TITLE
#162007294 Fix reset password error message

### DIFF
--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -279,13 +279,13 @@ class ResetPasswordSerializers(serializers.Serializer):
         email = data.get('email')
         user = User.objects.filter(email=email).first()
         if data.get('password') != data.get('confirm_password'):
-            msg = "Passwords do not match"
+            msg = "The passwords do not match."
             raise serializers.ValidationError(msg)
         # Confirm if token is valid
         token = data.get('token')
         validate_token = default_token_generator.check_token(user, token)
         if not validate_token:
-            msg = "Token is not valid or it has already expired"
+            msg = "Something went wrong. Try again."  # we don't want to give away security details
             raise serializers.ValidationError(msg)
         user.set_password(data.get('password'))
         user.save()

--- a/authors/apps/authentication/tests/api/test_email_password_reset.py
+++ b/authors/apps/authentication/tests/api/test_email_password_reset.py
@@ -127,7 +127,7 @@ class TestResetPassword(APITestCase):
         }
         response = self.client.put(self.reset_url, data=data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.content, b'{"errors":{"error":["Passwords do not match"]}}')
+        self.assertEqual(response.content, b'{"errors":{"error":["The passwords do not match."]}}')
 
     def test_invalid_password(self):
         """
@@ -168,5 +168,5 @@ class TestResetPassword(APITestCase):
         self.assertEqual(response2.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response2.content,
-            b'{"errors":{"error":["Token is not valid or it has already expired"]}}'
+            b'{"errors":{"error":["Something went wrong. Try again."]}}'
         )


### PR DESCRIPTION
**What does this PR do?**

This PR gives a better message when password token reset fails to work due to use of a different email address.

**Description of Task to be completed?**

##### Steps to reproduce
1. Go to forgot password page on the frontend and request a reset.
2. Open the link on the reset email.
3. Try using a different email to reset the password.

##### Expected
Should return a message "Something went wrong. Try again."

##### Actual
Displays "Token is not valid or it has already expired."
This is a security loophole and also users should not see such messages.

**How should this be manually tested?**

To test this manually:
1. Go to forgot password page on the frontend and request a reset.
2. Open the link on the reset email.
3. Try using a different email to reset the password.

You should see the error message: "Something went wrong. Try again."

**Any background context you want to provide?**

This issue was raised from a code review on 15-11-2018. It was decided that displaying the message "Token has expired" is a security loophole.

**What are the relevant pivotal tracker stories?**

[#162007294](https://www.pivotaltracker.com/story/show/162007294)

**Screenshots**
<img width="695" alt="screen shot 2018-11-16 at 12 48 25" src="https://user-images.githubusercontent.com/8180548/48613922-10289600-e99e-11e8-981f-5d030efb19b3.png">

