### PR TITLE
#162086149 Fix subscription notification management

### DIFF
--- a/authors/apps/ah_notifications/templates/unsubscribe_email.html
+++ b/authors/apps/ah_notifications/templates/unsubscribe_email.html
@@ -13,7 +13,8 @@ REQUIRED PARAMETERS:
     <div>
         <p>
             Dear <b>{{ username }}</b>,
-            You will no longer receive notifications on Authors' Haven. Click the Subscribe button below if you wish to resume your subscription.
+            You will no longer receive notifications on Authors' Haven. 
+            You will no longer receive notifications on articles you create and activities on people you follow.
         </p>
         <br/>
         <p>Happy Writing!</p>

--- a/authors/apps/ah_notifications/urls.py
+++ b/authors/apps/ah_notifications/urls.py
@@ -4,9 +4,10 @@ from .views import (
     AllNotificationsAPIView,
     UnreadNotificationsAPIView,
     ReadNotificationsAPIView,
-    UnsentNotificationsAPIView, 
+    UnsentNotificationsAPIView,
     SentNotificationsAPIView,
-    SubscribeAPIView
+    SubscribeAPIView,
+    SubscriptionStatusAPIView,
     )
 
 
@@ -19,5 +20,6 @@ urlpatterns = [
     path('read/<int:pk>/', ReadNotificationsAPIView.as_view(), name="read-notification"),
     path('unsent/', UnsentNotificationsAPIView.as_view(), name="unsent-notifications"),
     path('sent/', SentNotificationsAPIView.as_view(), name="sent-notifications"),
-    path('subscribe/', SubscribeAPIView.as_view(), name="subscribe")
+    path('subscribe/', SubscribeAPIView.as_view(), name="subscribe"),
+    path('subscription-status/', SubscriptionStatusAPIView.as_view(), name="subscription-status")
 ]


### PR DESCRIPTION
**What does this PR do?**
Fix subscription notification management. This adds an explicit way to subscribe and unsubscribe notifications. It also adds functionality to determine the subscription status of authenticated user.

**Description of Task to be completed?**

##### Steps to reproduce
1. Check the data of a specific user and note the value of `is_subscribed`.
2. Hit the `/notifications/subscribe` endpoint. You will get a notification indicating that notification subscription has been enabled or disabled depending on the initial status.
3. Check the value of `is_subscribed` again. It should be toggled. 

##### Expected
The response should indicate the new status of the notification subscription with a boolean.
There should be a way of getting the notification subscription status of the user.

##### Actual
The response just gives the message.
There is also no way to query the current subscription status of the user.

**How should this be manually tested?**
This can be manually via the following endpoints:
1. `POST /api/notifications/subscribe/` to subscribe.
2. `DELETE /notifications/subscribe/` to unsubscribe.
3. `GET /subscription-status/` to view subscription status.

**What are the relevant pivotal tracker stories?**

[#162086149](https://www.pivotaltracker.com/story/show/162086149)

**Screenshots**
<img width="822" alt="screen shot 2018-11-20 at 18 44 57" src="https://user-images.githubusercontent.com/31212441/48784944-bead3d80-ecf4-11e8-9096-d63c97c71897.png">

<img width="822" alt="screen shot 2018-11-20 at 18 45 21" src="https://user-images.githubusercontent.com/31212441/48784883-9c1b2480-ecf4-11e8-8c17-4d91f90fd4c8.png">

<img width="824" alt="screen shot 2018-11-20 at 18 46 07" src="https://user-images.githubusercontent.com/31212441/48784875-9a516100-ecf4-11e8-812c-aa941ebe9204.png">