### PR TITLE
[Bug #162113329] Enable a user to check whether they are being followed

### DIFF
--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import ProfileListView, ProfileGetView, FollowUnFollowView, FollowersView, FollowingView
+from .views import ProfileListView, ProfileGetView, FollowUnFollowView, FollowersView, FollowingView, FollowingUserView
 
 app_name = 'profiles'
 
@@ -9,4 +9,5 @@ urlpatterns = [
     path('<str:username>/follow/', FollowUnFollowView.as_view(), name="follow"),
     path('<str:username>/followers/', FollowersView.as_view(), name="followers"),
     path('<str:username>/following/', FollowingView.as_view(), name="following"),
+    path('following/<str:username>', FollowingUserView.as_view(), name="is-following"),
 ]

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -165,3 +165,16 @@ class FollowingView(FollowMixin):
             'followers': serializer.data
         }
         return Response(data, status=status.HTTP_200_OK)
+
+class FollowingUserView(FollowMixin):
+    def get(self, request, username):
+        """
+        Determine whether auth user is following user with username.
+        """
+        auth_profile = request.user.profile
+        other_profile = self.get_user_profile(username)
+        is_following = other_profile.followed_by.filter(user=auth_profile.user).exists()
+        data = {
+            "following_status": is_following
+        }
+        return Response(data, status=status.HTTP_200_OK);


### PR DESCRIPTION
**What does this PR do?**

* fixes a bug on following/unfollowing feature

**How should this be manually tested?**

* clone this repository on your local machine
* create a virtual environment e.g. `virtualenv env` and activate it
* create a .env file e.g. 
```
source env/bin/activate
export DB_NAME=your_database_name
export DB_USER=your_database_user
export DB_PASSWORD=your_database_password
export DB_HOST=localhost
export EMAIL_HOST=smtp.sendgrid.net
export EMAIL_HOST_USER=
export EMAIL_HOST_PASSWORD=
export EMAIL_PORT=587
export EMAIL_SENDER=info@authorshaven.com
export TIME_DELTA=6000
export CLOUDINARY_NAME=sample
export CLOUDINARY_KEY=
export CLOUDINARY_SECRET=
```

* update dependensies `pip install -r requirements.txt`
*run server `python manage.py runserver`
* Navigate to the endpoint below through Postman

| Endpoint        | Functionality        
| ------------- |-------------| 
| GET api/profiles/following/<username>| Checks whether a user is following you or not |

**What are the relevant pivotal tracker stories?**

[#162113329](https://www.pivotaltracker.com/story/show/162113329)

**Screenshots (if appropriate)**

* if a user is following you
<img width="1137" alt="screenshot 2018-11-21 at 13 39 37" src="https://user-images.githubusercontent.com/38909130/48837762-46e41f00-ed97-11e8-822b-160752025b1e.png">


* if a user is not following you
<img width="1130" alt="screenshot 2018-11-21 at 13 39 18" src="https://user-images.githubusercontent.com/38909130/48837754-3d5ab700-ed97-11e8-80ec-e9710019212e.png">




**Questions:**

N/A