### PR TITLE
#162159287 Add more article stats

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -8,7 +8,6 @@ from authors.apps.authentication.models import User
 from authors.apps.core.models import TimestampsMixin, SoftDeleteMixin
 from notifications.signals import notify
 from authors.apps.ah_notifications.notifications import Verbs
-from rest_framework.reverse import reverse
 
 
 class ReactionMixin(models.Model):

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -389,6 +389,9 @@ def update(request, key):
 class StatsSerializer(serializers.ModelSerializer):
     view_count = serializers.SerializerMethodField()
     comment_count = serializers.SerializerMethodField()
+    like_count = serializers.SerializerMethodField()
+    dislike_count = serializers.SerializerMethodField()
+    average_rating = serializers.SerializerMethodField()
 
     def get_comment_count(self, value):
         return Comment.objects.filter(article=value).count()
@@ -396,9 +399,19 @@ class StatsSerializer(serializers.ModelSerializer):
     def get_view_count(self, value):
         return ArticleView.objects.filter(article=value).count()
 
+    def get_like_count(self, value):
+        return value.likes.count()
+
+    def get_dislike_count(self, value):
+        return value.dislikes.count()
+
+    def get_average_rating(self, value):
+        return ArticleRating.objects.filter(article=value).aggregate(
+            average_rating=models.Avg('rating'))['average_rating'] or 0
+
     class Meta:
         model = Article
-        fields = ['slug', 'title', 'view_count', 'comment_count']
+        fields = ['slug', 'title', 'view_count', 'comment_count', 'like_count', 'dislike_count', 'average_rating']
 
 
 class ReporterField(serializers.RelatedField):


### PR DESCRIPTION
**What does this PR do?**

This PR adds more data to article stats for the benefit of the user.

**Description of Task to be completed?**

Other than `view count` and `comment count`, it will be important to provide the user with `like count`, `dislike count` and `average_rating`.

**How should this be manually tested?**

To manually test using Postman.
1. Ensure that env variables are exported.
2. Run the application `python manage.py runserver`
3. Create articles on the endpoint `POST /api/articles/`
4. Like articles on the endpoint `POST /api/articles/<str:slug>/like/`
5. Dislike articles on the endpoint `POST /api/articles/<str:slug>/dislike/`
6. Rate articles on the endpoint `PUT /api/articles/<slug>/rate/`
7. Get article stats on the endpoint `GET /article-stats/`

**What are the relevant pivotal tracker stories?**

[#162159287](https://www.pivotaltracker.com/story/show/162159287)

**Screenshots**
<img width="858" alt="screen shot 2018-11-23 at 08 34 41" src="https://user-images.githubusercontent.com/8180548/48929532-c6d6ca00-eefa-11e8-8fff-dc7d5f60b1a1.png">
